### PR TITLE
Fix: Modify typeName driver/mysql

### DIFF
--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -17,17 +17,15 @@ type Driver struct{}
 
 func typeName(s string) string {
 	switch s {
-	case "binary", "blob", "tinyblob", "longblob":
+	case "binary", "blob":
 		return "Bytes"
 	case "tinyint", "smallint", "mediumint", "int", "integer", "bigint":
 		return "Int"
-	case "float":
+	case "float", "double", "double precision", "real":
 		return "Float"
-	case "double", "double precision", "real":
-		return "Float"
-	case "char", "tinytext", "text", "longtext":
-		return "Float"
-	case "datetime":
+	case "char", "varchar", "tinytext", "text", "longtext":
+		return "String"
+	case "datetime", "date", "time", "timestamp":
 		return "Time"
 	}
 	return "Unknown"


### PR DESCRIPTION
Fixed the return value of the field in mysql

+ ref: https://dev.mysql.com/doc/refman/8.0/ja/data-types.html

# Test

+ run

```shell
go run main.go -driver mysql -dsn "root:example@tcp(127.0.0.1:3306)/entgen"
```

```go
package schema

import (
	"time"

	"entgo.io/ent"
	"entgo.io/ent/schema/field"
)

// Field_sample holds the schema definition for the Field_sample entity.
type Field_sample struct {
	ent.Schema
}

// Fields of the Field_sample.
func (Field_sample) Fields() []ent.Field {
	return []ent.Field{
		field.Int("i1"),
		field.Int("i2"),
		field.Int("i3"),
		field.Int("i4"),
		field.Int("i5"),
		field.Int("i6"),
		field.Unknown("d1"),
		field.Unknown("d2"),
		field.Float("f1"),
		field.Float("f2"),
		field.Unknown("b"),
		field.Time("dat1").
			Default(time.Now),
		field.Time("dat2").
			Default(time.Now),
		field.Time("dat3").
			Default(time.Now),
		field.Time("dat4").
			Default(time.Now),
		field.Time("dat5").
			Default(time.Now),
		field.String("c1").
			NotEmpty().
			MaxLen(1),
		field.String("c2").
			NotEmpty().
			MaxLen(1),
		field.Bytes("c3").
			NotEmpty().
			MaxLen(1),
		field.Unknown("c4").
			MaxLen(1),
		field.Bytes("c5").
			NotEmpty().
			MaxLen(65535),
		field.String("c6").
			NotEmpty().
			MaxLen(65535),
		field.Unknown("c7").
			MaxLen(1),
		field.Unknown("c8").
			MaxLen(3),
	}
}
```

## docker-compose.yml

```docker
version: '3.1'
services:
  db:
    image: mysql:8.0
    platform: linux/x86_64
    command: --default-authentication-plugin=mysql_native_password
    restart: always
    environment:
      MYSQL_DATABASE: entgen
      MYSQL_ROOT_PASSWORD: example
    ports:
      - "3306:3306"      
```

## table.sql


```sql
CREATE TABLE field_sample (
    -- https://dev.mysql.com/doc/refman/8.0/ja/numeric-types.html
    i1 INT,
    i2 INTEGER,
    i3 SMALLINT,
    i4 TINYINT,
    i5 MEDIUMINT,
    i6 BIGINT,
    d1 DECIMAL(5,2),
    d2 NUMERIC(5,2),
    f1 FLOAT(7,4),
    f2 DOUBLE(7,4),
    b BIT(1),
    -- https://dev.mysql.com/doc/refman/8.0/ja/date-and-time-types.html
    dat1 DATETIME,
    dat2 DATE,
    dat3 TIMESTAMP,
    dat4 TIME,
    dat5 YEAR,
    -- https://dev.mysql.com/doc/refman/8.0/ja/string-types.html
    c1 CHAR(1),
    c2 VARCHAR(1),
    c3 BINARY(1),
    c4 VARBINARY(1),
    c5 BLOB,
    c6 TEXT,
    c7 ENUM('1','2'),
    c8 SET('1','2')
)
```


```shell
mysql> desc field_sample;
+-------+---------------+------+-----+---------+-------+
| Field | Type          | Null | Key | Default | Extra |
+-------+---------------+------+-----+---------+-------+
| i1    | int           | YES  |     | NULL    |       |
| i2    | int           | YES  |     | NULL    |       |
| i3    | smallint      | YES  |     | NULL    |       |
| i4    | tinyint       | YES  |     | NULL    |       |
| i5    | mediumint     | YES  |     | NULL    |       |
| i6    | bigint        | YES  |     | NULL    |       |
| d1    | decimal(5,2)  | YES  |     | NULL    |       |
| d2    | decimal(5,2)  | YES  |     | NULL    |       |
| f1    | float(7,4)    | YES  |     | NULL    |       |
| f2    | double(7,4)   | YES  |     | NULL    |       |
| b     | bit(1)        | YES  |     | NULL    |       |
| dat1  | datetime      | YES  |     | NULL    |       |
| dat2  | date          | YES  |     | NULL    |       |
| dat3  | timestamp     | YES  |     | NULL    |       |
| dat4  | time          | YES  |     | NULL    |       |
| dat5  | year          | YES  |     | NULL    |       |
| c1    | char(1)       | YES  |     | NULL    |       |
| c2    | varchar(1)    | YES  |     | NULL    |       |
| c3    | binary(1)     | YES  |     | NULL    |       |
| c4    | varbinary(1)  | YES  |     | NULL    |       |
| c5    | blob          | YES  |     | NULL    |       |
| c6    | text          | YES  |     | NULL    |       |
| c7    | enum('1','2') | YES  |     | NULL    |       |
| c8    | set('1','2')  | YES  |     | NULL    |       |
+-------+---------------+------+-----+---------+-------+
24 rows in set (0.06 sec)
```

