### PR TITLE
fix: field types has been set Unknown by sqlite3 driver.

### DIFF
--- a/driver/sqlite3/sqlite3.go
+++ b/driver/sqlite3/sqlite3.go
@@ -124,7 +124,7 @@ func (*Driver) Columns(db *sql.DB, name string) ([]driver.Column, error) {
 				d = fmt.Sprintf("%q", sd)
 			}
 		}
-		t = typeName(t)
+		t = typeName(strings.ToLower(t))
 		columns = append(columns, driver.Column{
 			Name:      driver.Camelize(s),
 			Orig:      s,


### PR DESCRIPTION
Some field types has been set `Unknown` by sqlite3 driver.
Probably, pragma returns types with upper case if types match affinity.

## Confirmation
Under the following condition
- Docker image: golang:1.18.3-alpine3.16
- sqlite: 3.38.5-r0

Create database
```bash
$ echo 'CREATE TABLE `users` (`id` integer PRIMARY KEY NOT NULL, `age` integer, `name` text);' | sqlite3 users.sqlite
```

Output table info
```bash
$ sqlite3 users.sqlite
sqlite> pragma table_info(users);
0|id|INTEGER|1||1
1|age|INTEGER|0||0
2|name|TEXT|0||0
```

## Test

Generate
```bash
$ go run main.go -driver sqlite3 -dsn ./users.sqlite -rplural
```

Confirm _ent/schema/user.go_
```ent/schema/user.go 
package schema

import (
        "entgo.io/ent"
        "entgo.io/ent/schema/field"
)

// User holds the schema definition for the User entity.
type User struct {
        ent.Schema
}

// Fields of the User.
func (User) Fields() []ent.Field {
        return []ent.Field{
                field.Int("age").
                        NotEmpty(),
                field.String("name").
                        NotEmpty(),
        }
}
```
